### PR TITLE
Update Docker Image to Alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2 - 2022-07-06
+
+- Migrate to Alpine tools.deps image
+- Add an output group for files that will be linted
+
 ## v1 - 2021-07-07
 
 - Initial Implementation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nnichols/clojure-lint-action
+FROM clojure:openjdk-8-tools-deps-slim-buster
 
 ENV REVIEWDOG_VERSION=v0.12.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,16 @@ ENV REVIEWDOG_VERSION=v0.12.0
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
+RUN apk --no-cache add gcc ncurses-dev libc-dev readline-dev make \
+    && cd /tmp \
+    && wget https://github.com/hanslub42/rlwrap/releases/download/v0.43/rlwrap-0.43.tar.gz \
+    && tar -xzvf rlwrap-0.43.tar.gz \
+    && cd rlwrap-0.43 \
+    && ./configure \
+    && make install \
+    && rm -rf rlwrap-0.43 \
+    && apk del gcc ncurses-dev libc-dev readline-dev make
+
 COPY lint.sh /lint.sh
 
 ENTRYPOINT ["bash", "/lint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-8-tools-deps-slim-buster
+FROM clojure:temurin-18-tools-deps-alpine
 
 ENV REVIEWDOG_VERSION=v0.12.0
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default: `.`
 Optional.
 File patterns of target files.
 Same as `-name [pattern]` of `find` command.
-Default: `*.clj,*.cljc,*.cljs,*.cljx`
+Default: `*.clj*` (To capture `*.clj`, `*.cljs`, `*.cljc`, and `*.cljx`)
 
 ### `exclude`
 
@@ -72,6 +72,8 @@ Default: `'{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'`
 
 ### [.github/workflows/reviewdog.yml](.github/workflows/reviewdog.yml)
 
+To receive automatic Pull Request comments with linter results:
+
 ```yml
 name: Lint Clojure
 on: [pull_request]
@@ -80,12 +82,12 @@ jobs:
     name: runner / clj-kondo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3.0.2
       - name: clj-kondo
-        uses: nnichols/clojure-lint-action@v1
+        uses: nnichols/clojure-lint-action@v2
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review # Change reporter.
+          reporter: github-pr-review
 ```
 
 ## Licensing

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
   pattern:
     required: false
     description: "File patterns of target files. Same as `-name [pattern]` of `find` command."
-    default: '*.clj'
+    default: '*.clj*'
   exclude:
     required: false
     description: "Exclude patterns of target files. Same as `-not -path [exclude]` of `find` command."

--- a/lint.sh
+++ b/lint.sh
@@ -18,11 +18,16 @@ for source in $sources; do
     SOURCES="${SOURCES} --lint=${source}"
 done
 
-clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
+results=$(clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
   --lint "${SOURCES}" \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
-  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}" :summary false}}' \
-  | reviewdog \
+  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}" :summary false}}')
+
+echo "::group::Linter results"
+echo "${results}"
+echo "::endgroup::"
+
+echo $results | reviewdog \
       -efm="%f:%l:%c: %m" \
       -name="clj-kondo" \
       -reporter="${INPUT_REPORTER}" \

--- a/lint.sh
+++ b/lint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 cd "${GITHUB_WORKSPACE}" || exit
+
+# https://github.com/reviewdog/reviewdog/issues/1158
 git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"

--- a/lint.sh
+++ b/lint.sh
@@ -13,10 +13,11 @@ echo "::group::Files to lint"
 echo "${sources}"
 echo "::endgroup::"
 
-clj-kondo --lint $(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}") \
+clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
+  --lint $(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}") \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
-  --config '{:summary false}'
+  --config '{:summary false}' \
   | reviewdog \
       -efm="%f:%l:%c: %m" \
       -name="clj-kondo" \

--- a/lint.sh
+++ b/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd "${GITHUB_WORKSPACE}" || exit
+cd "${GITHUB_WORKSPACE}" || exit 1
 
 # https://github.com/reviewdog/reviewdog/issues/1158
 git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit 1
@@ -21,7 +21,7 @@ done
 clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
   --lint "${SOURCES}" \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
-  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
+  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}" :summary false}}' \
   | reviewdog \
       -efm="%f:%l:%c: %m" \
       -name="clj-kondo" \
@@ -30,3 +30,7 @@ clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-ko
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       "${INPUT_REVIEWDOG_FLAGS}"
+
+exit_code=$?
+
+exit $exit_code

--- a/lint.sh
+++ b/lint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 cd "${GITHUB_WORKSPACE}" || exit
+git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit 1
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 

--- a/lint.sh
+++ b/lint.sh
@@ -15,11 +15,11 @@ echo "::endgroup::"
 
 SOURCES=""
 for source in $sources; do
-    SOURCES="${SOURCES} --lint=${source}"
+    SOURCES="${SOURCES} --lint ${source}"
 done
 
 results=$(clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
-  --lint "${SOURCES}" \
+  "${SOURCES}" \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}" :summary false}}')
 

--- a/lint.sh
+++ b/lint.sh
@@ -13,8 +13,13 @@ echo "::group::Files to lint"
 echo "${sources}"
 echo "::endgroup::"
 
+SOURCES=""
+for source in $sources; do
+    SOURCES="${SOURCES} --lint=${source}"
+done
+
 clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
-  --lint $source \
+  --lint "${SOURCES}" \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
   | reviewdog \

--- a/lint.sh
+++ b/lint.sh
@@ -4,7 +4,14 @@ cd "${GITHUB_WORKSPACE}" || exit
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-clj-kondo --lint $(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}") \
+sources=$(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}")
+
+echo "::group::Files to lint"
+echo "${sources}"
+echo "::endgroup::"
+
+clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
+  --lint $source \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
   | reviewdog \
@@ -14,4 +21,4 @@ clj-kondo --lint $(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -n
       -filter-mode="${INPUT_FILTER_MODE}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
-      ${INPUT_REVIEWDOG_FLAGS}
+      "${INPUT_REVIEWDOG_FLAGS}"

--- a/lint.sh
+++ b/lint.sh
@@ -13,21 +13,11 @@ echo "::group::Files to lint"
 echo "${sources}"
 echo "::endgroup::"
 
-SOURCES=""
-for source in $sources; do
-    SOURCES="${SOURCES} --lint ${source}"
-done
-
-results=$(clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
-  "${SOURCES}" \
+clj-kondo --lint $(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}") \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
-  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}" :summary false}}')
-
-echo "::group::Linter results"
-echo "${results}"
-echo "::endgroup::"
-
-echo $results | reviewdog \
+  --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
+  --config '{:summary false}'
+  | reviewdog \
       -efm="%f:%l:%c: %m" \
       -name="clj-kondo" \
       -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
# Proposed Changes

- Additions: Adds an output group of the files that were detected
- Updates: Use Alpine image instead of `clj-kondo` image. This allows the action to consistently pull the latest `clj-kondo` dependency regardless of any image caching
- Deletions: N/A

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
