### PR TITLE
User overrides of kondo version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v7 - 2026-05-21
+
+- Allows overriding the running version of clj-kondo with `clj_kondo_version`.
+
 ## v6 - 2025-08-16
 
 - Enable parallel clj-kondo execution

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2025 Nick A Nichols
+Copyright (c) 2021-2026 Nick A Nichols
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Optional.
 Flags to pass to clj-kondo's `--config` option, which may either be in-line options or a path to a config file.
 Default: `'{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'`
 
+### `clj_kondo_version`
+
+Optional.
+Specifies the version of clj-kondo to use, passed as `:mvn/version` in clj-kondo's dependency map.
+e.g. `2026.04.15`.
+Default: `RELEASE`, which resolves to the latest published version at run time.
+
 ## Example usage
 
 ### Sample workflow

--- a/action.yml
+++ b/action.yml
@@ -59,3 +59,7 @@ inputs:
     required: false
     description: "Flags to pass to clj-kondo's `--config` option, which may either be in-line options or a path to a config file."
     default: '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'
+  clj_kondo_version:
+    required: false
+    description: "Version of clj-kondo to use, passed as the value of `:mvn/version` in clj-kondo's dependency map (e.g., `2026.04.15`). Defaults to `RELEASE` to preserve existing behavior."
+    default: 'RELEASE'

--- a/action.yml
+++ b/action.yml
@@ -61,5 +61,5 @@ inputs:
     default: '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'
   clj_kondo_version:
     required: false
-    description: "Version of clj-kondo to use, passed as the value of `:mvn/version` in clj-kondo's dependency map (e.g., `2026.04.15`). Defaults to `RELEASE` to preserve existing behavior."
+    description: "Version of clj-kondo to use, passed as the value of `:mvn/version` in clj-kondo's dependency map (e.g., `2026.04.15`). Defaults to `RELEASE`."
     default: 'RELEASE'

--- a/lint.sh
+++ b/lint.sh
@@ -13,6 +13,7 @@ echo "INPUT_PATH: ${INPUT_PATH}"
 echo "INPUT_EXCLUDE: ${INPUT_EXCLUDE}"
 echo "INPUT_PATTERN: ${INPUT_PATTERN}"
 echo "INPUT_CLJ_KONDO_CONFIG: ${INPUT_CLJ_KONDO_CONFIG}"
+echo "INPUT_CLJ_KONDO_VERSION: ${INPUT_CLJ_KONDO_VERSION}"
 echo "INPUT_REPORTER: ${INPUT_REPORTER}"
 echo "INPUT_FILTER_MODE: ${INPUT_FILTER_MODE}"
 echo "INPUT_FAIL_ON_ERROR: ${INPUT_FAIL_ON_ERROR}"
@@ -26,7 +27,7 @@ echo "::group::Files to lint"
 echo "${sources}"
 echo "::endgroup::"
 
-clj -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}' -M -m clj-kondo.main \
+clj -Sdeps "{:deps {clj-kondo/clj-kondo {:mvn/version \"${INPUT_CLJ_KONDO_VERSION}\"}}}" -M -m clj-kondo.main \
   --lint ${sources} \
   --config "${INPUT_CLJ_KONDO_CONFIG}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \


### PR DESCRIPTION
# Proposed Changes

- Additions: 
  - An optional `clj_kondo_version` input to control the version of the linter over time. Defaults to `RELEASE`

## Pre-merge Checklist

- [x] Write + run tests
  - Verified with https://github.com/Wall-Brew-Co/brew-bot/actions/runs/26289805544/job/77386725153?pr=378
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
