### PR TITLE
v8 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v8 - 2026-06-02
+
+- Bumps Temurin image to v21 as a base
+- Remove in-image dependency pins
+- Bumps Reviewdog base version to 21
+- Documents passing in-line clj-kondo config to the action
+- Emits better logs to differentiate clj-kondo and reviewdog failures
+
 ## v7 - 2026-05-21
 
 - Allows overriding the running version of clj-kondo with `clj_kondo_version`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,10 @@
-# https://hub.docker.com/layers/library/clojure/temurin-18-tools-deps-alpine/images/sha256-11322c60157b98e87bd55d523854d177e4b150f7b0ca2179550d7cd2a60961f8
-FROM clojure:temurin-18-tools-deps-alpine@sha256:3c4b747a4cf5681cf2b398cd3d38778f143acec6c937627ecb05ef09252db4e3
+# https://hub.docker.com/layers/library/clojure/temurin-21-tools-deps-alpine/images/sha256-e7534968e364dd5457785a57d8e8e4b6e0f581110b4c4a40194ad6c115633e43
+FROM clojure:temurin-21-tools-deps-alpine@sha256:e7534968e364dd5457785a57d8e8e4b6e0f581110b4c4a40194ad6c115633e43
 
-# https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#v0181---2024-06-22
-ENV REVIEWDOG_VERSION=v0.18.1
+# https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md#v0210---2025-09-03
+ENV REVIEWDOG_VERSION=v0.21.0
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
-
-RUN apk --no-cache add gcc ncurses-dev libc-dev readline-dev make \
-    && cd /tmp \
-    && wget https://github.com/hanslub42/rlwrap/releases/download/v0.43/rlwrap-0.43.tar.gz \
-    && tar -xzvf rlwrap-0.43.tar.gz \
-    && cd rlwrap-0.43 \
-    && ./configure \
-    && make install \
-    && rm -rf rlwrap-0.43 \
-    && apk del gcc ncurses-dev libc-dev readline-dev make
 
 COPY lint.sh /lint.sh
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ e.g. `./.git/*`
 
 Optional.
 Flags to pass to clj-kondo's `--config` option, which may either be in-line options or a path to a config file.
-Default: `'{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'`
+Default: `''` (no additional config passed to clj-kondo).
+
+The action sets clj-kondo's output pattern to `{{filename}}:{{row}}:{{col}}: {{message}}` so that reviewdog can parse the output via its `-efm` errorformat.
+This pattern is fixed by the action and is not user-configurable; user-supplied `clj_kondo_config` values may adjust linters and other clj-kondo settings, but any output pattern they pass will be overridden by the action.
 
 ### `clj_kondo_version`
 

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
   clj_kondo_config:
     required: false
     description: "Flags to pass to clj-kondo's `--config` option, which may either be in-line options or a path to a config file."
-    default: '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}'
+    default: ''
   clj_kondo_version:
     required: false
     description: "Version of clj-kondo to use, passed as the value of `:mvn/version` in clj-kondo's dependency map (e.g., `2026.04.15`). Defaults to `RELEASE`."

--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 
 cd "${GITHUB_WORKSPACE}" || exit 1
 
@@ -42,7 +43,7 @@ clj -Sdeps "{:deps {clj-kondo/clj-kondo {:mvn/version \"${INPUT_CLJ_KONDO_VERSIO
       -level="${INPUT_LEVEL}" \
       "${INPUT_REVIEWDOG_FLAGS}"
 
-exit_code=$?
-echo "clj-kondo finished with exit code: ${exit_code}"
+exit_code=$? kondo_exit_code=${PIPESTATUS[0]}
+echo "clj-kondo finished with exit code: ${kondo_exit_code}"
 
 exit $exit_code


### PR DESCRIPTION
# Proposed Changes

- Additions:
  - Documents passing in-line clj-kondo config to the action
- Emits better logs to differentiate clj-kondo and reviewdog failures
- Updates:
  - Bumps Temurin image to v21 as a base
  - Bumps Reviewdog base version to 21
- Deletions:
  - Remove in-image dependency pins

## Pre-merge Checklist

- [x] Write + run tests
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
