### PR TITLE
Fix the error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v10 - 2026-06-06
+
+- Scopes the lint file search to real Clojure source extensions (`.clj`, `.cljs`, `.cljc`, `.cljx`, `.cljd`, `.cljr`) and always prunes `.git`, so Git internals are no longer linted.
+  Previously the default `*.clj*` pattern matched `.clj` anywhere in a path; on branches whose name contains `.clj` it fed Git ref files to clj-kondo and failed the run.
+  The `pattern` input default changed from `*.clj*` to empty, where empty selects the standard extensions; an explicit `pattern` is still honored verbatim.
+- Passes `--config` to clj-kondo only when `clj_kondo_config` is set, removing a misleading `error while reading <workspace> (No such file or directory)` warning on default runs.
+- Emits an `::error::` annotation naming clj-kondo and its exit code on failure, and logs both clj-kondo and reviewdog exit codes, to make failures easier to triage.
+
 ## v9 - 2026-06-02
 
 - Asserts Release Immutability in GitHub.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ The clojure-lint-action is used in almost every Wall Brew repository.
 If you'd like to see a sample GitHub workflow using this linter, please check out [spoon](https://github.com/Wall-Brew-Co/spoon/blob/1ec5a26e49561f6c653bbba666a024a9924cf831/.github/workflows/lint.yml#L33 "An example workflow file using this action.")
 That action was used as a CI/CD check in this [Pull Request.](https://github.com/Wall-Brew-Co/spoon/pull/14 "An example PR with 2 linter warnings written as comments")
 
+### Sample Workflow
+
+To receive automatic Pull Request comments with linter results:
+
+```yml
+name: Lint Clojure
+on: [pull_request]
+jobs:
+  clj-kondo:
+    name: runner / clj-kondo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: clj-kondo
+        uses: nnichols/clojure-lint-action@v10
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+```
+
 ## Inputs
 
 ### `github_token`
@@ -45,6 +65,7 @@ Optional.
 Sets an exceptional exit code for reviewdog when errors are found.
 Must be one of `[true, false]`.
 Default is `false`.
+This is the authoritative control for whether lint findings fail the step; see [Failure handling](#failure-handling).
 
 ### `reviewdog_flags`
 
@@ -61,16 +82,17 @@ Default: `.`
 ### `pattern`
 
 Optional.
-File patterns of target files.
-Same as `-name [pattern]` of `find` command.
-Default: `*.clj*` (matches `*.clj`, `*.cljs`, `*.cljc`, `*.cljx`, and any other `*.clj*` filename)
+File name pattern for target files, used verbatim as the `-name [pattern]` test of the `find` command.
+Default: empty, which matches the standard Clojure source extensions: `*.clj`, `*.cljs`, `*.cljc`, `*.cljx`, `*.cljd`, `*.cljr`.
+The `.git` directory is always pruned, so Git internals are never linted regardless of branch name.
 
 ### `exclude`
 
 Optional.
 Exclude patterns of target files.
 Same as `-not -path [exclude]` of `find` command.
-e.g. `./.git/*`
+e.g. `./target/*`
+Note: `.git` is always excluded, so you do not need to list it here.
 
 ### `clj_kondo_config`
 
@@ -88,27 +110,15 @@ Specifies the version of clj-kondo to use, passed as `:mvn/version` in clj-kondo
 e.g. `2026.04.15`.
 Default: `RELEASE`, which resolves to the latest published version at run time.
 
-## Example usage
+## Failure Handling
 
-### Sample workflow
+clj-kondo's findings are piped to reviewdog.
+Whether the step fails is controlled by `fail_on_error` (with `level`), which govern reviewdog's exit code.
+With the default `fail_on_error: false`, findings are reported as annotations or PR comments without failing the build.
 
-To receive automatic Pull Request comments with linter results:
+An internal clj-kondo error (exit code 1) always fails the step, even when `fail_on_error` is `false`, so a linter crash is never silently green.
 
-```yml
-name: Lint Clojure
-on: [pull_request]
-jobs:
-  clj-kondo:
-    name: runner / clj-kondo
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: clj-kondo
-        uses: nnichols/clojure-lint-action@v6
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-```
+Each run logs the clj-kondo and reviewdog exit codes and emits an `::error::` annotation when clj-kondo exits non-zero, to make failures easier to triage.
 
 ## Licensing
 

--- a/action.yml
+++ b/action.yml
@@ -50,8 +50,11 @@ inputs:
     default: '.'
   pattern:
     required: false
-    description: "File patterns of target files. Same as `-name [pattern]` of `find` command."
-    default: '*.clj*'
+    description: |
+      File name pattern for target files, used verbatim as the `-name [pattern]` test of the `find` command.
+      Leave empty (the default) to match the standard Clojure source extensions: .clj, .cljs, .cljc, .cljx, .cljd, .cljr.
+      The `.git` directory is always pruned, so Git internals are never linted regardless of branch name.
+    default: ''
   exclude:
     required: false
     description: "Exclude patterns of target files. Same as `-not -path [exclude]` of `find` command."

--- a/lint.sh
+++ b/lint.sh
@@ -22,15 +22,41 @@ echo "INPUT_LEVEL: ${INPUT_LEVEL}"
 echo "INPUT_REVIEWDOG_FLAGS: ${INPUT_REVIEWDOG_FLAGS}"
 echo "::endgroup::"
 
-sources=$(find "${INPUT_PATH}" -not -path "${INPUT_EXCLUDE}" -type f -name "${INPUT_PATTERN}")
+# Match file names by extension suffix, not as a substring.
+# Default to standard Clojure extensions; a user-supplied INPUT_PATTERN is used verbatim.
+if [ -n "${INPUT_PATTERN}" ]; then
+  name_expr=( -name "${INPUT_PATTERN}" )
+else
+  name_expr=( \( -name '*.clj' -o -name '*.cljs' -o -name '*.cljc' -o -name '*.cljx' -o -name '*.cljd' -o -name '*.cljr' \) )
+fi
+
+# Apply INPUT_EXCLUDE only when set, and always prune .git
+# Prevents Git internals from being linted, regardless of branch name.
+exclude_expr=()
+if [ -n "${INPUT_EXCLUDE}" ]; then
+  exclude_expr=( -not -path "${INPUT_EXCLUDE}" )
+fi
+
+sources=$(find "${INPUT_PATH}" \
+  -name .git -prune -o \
+  -type f "${name_expr[@]}" "${exclude_expr[@]}" -print)
 
 echo "::group::Files to lint"
 echo "${sources}"
 echo "::endgroup::"
 
+# Pass a user --config only when set.
+# clj-kondo treats a --config value that does not start with "{" (including the empty string) as a file path.
+# This prints a misleading "error while reading <workspace> (No such file or directory)".
+config_args=()
+if [ -n "${INPUT_CLJ_KONDO_CONFIG}" ]; then
+  config_args=( --config "${INPUT_CLJ_KONDO_CONFIG}" )
+fi
+
+echo "::group::Execution Logs"
 clj -Sdeps "{:deps {clj-kondo/clj-kondo {:mvn/version \"${INPUT_CLJ_KONDO_VERSION}\"}}}" -M -m clj-kondo.main \
   --lint ${sources} \
-  --config "${INPUT_CLJ_KONDO_CONFIG}" \
+  "${config_args[@]}" \
   --config '{:output {:pattern "{{filename}}:{{row}}:{{col}}: {{message}}"}}' \
   --config '{:summary false}' \
   --parallel \
@@ -43,7 +69,29 @@ clj -Sdeps "{:deps {clj-kondo/clj-kondo {:mvn/version \"${INPUT_CLJ_KONDO_VERSIO
       -level="${INPUT_LEVEL}" \
       "${INPUT_REVIEWDOG_FLAGS}"
 
-exit_code=$? kondo_exit_code=${PIPESTATUS[0]}
-echo "clj-kondo finished with exit code: ${kondo_exit_code}"
+# Capture pipeline statuses immediately.
+# Required to run prior to the following echo
+kondo_exit_code=${PIPESTATUS[0]} reviewdog_exit_code=${PIPESTATUS[1]}
 
-exit $exit_code
+echo "::endgroup::"
+
+echo "clj-kondo finished with exit code: ${kondo_exit_code}"
+echo "reviewdog finished with exit code: ${reviewdog_exit_code}"
+
+# clj-kondo exit codes:
+#
+#   0 = no findings
+#   1 = internal error
+#   2 = warnings surfaced by the linter
+#   3 = errors surfaced by the linter
+if [ "${kondo_exit_code}" -ne 0 ]; then
+  echo "::error::clj-kondo exited ${kondo_exit_code} (0=clean, 1=internal, 2=warnings, 3=errors)."
+fi
+
+# An internal clj-kondo error (exit 1) must fail the execution.
+# ::error:: annotations do not fail a step on their own.
+if [ "${kondo_exit_code}" -eq 1 ]; then
+  exit 1
+fi
+
+exit $reviewdog_exit_code


### PR DESCRIPTION
# Proposed Changes

- Additions:
  - `lint.sh`: emit a `::error::` annotation with clj-kondo's exit code on any non-zero result, log both the clj-kondo and reviewdog exit codes, and fail the step on a clj-kondo internal error (exit 1) so a linter crash is never silently green.

- Updates:
  - `lint.sh`: scope the file search to real Clojure source extensions (`.clj .cljs .cljc .cljx .cljd .cljr`) and always prune `.git`, instead of the `*.clj*` substring match that fed Git ref files to clj-kondo on branches whose name contains `.clj` (e.g. `dependencies/com.github.clj-kondo-...`).
  - `lint.sh`: pass `--config` to clj-kondo only when `clj_kondo_config` is set, removing the misleading `error while reading <workspace>` warning on default runs.
  - `action.yml`: `pattern` input default changed from `*.clj*` to empty (empty selects the standard extensions; an explicit value is still used verbatim).
  - `README.md`: refresh `pattern`, `exclude`, and `fail_on_error` docs and bump the example pin to `@v10`.

- Deletions:
  - Removed the unconditional `--config "${INPUT_CLJ_KONDO_CONFIG}"` argument.
  - Removed the `*.clj*` substring default and the obsolete `./.git/*` `exclude` example.

## Pre-merge Checklist

- [x] Write + run tests
  - [x] Testing against: https://github.com/Wall-Brew-Co/lein-sealog/pull/171 
- [x] Update CHANGELOG and increment version
- [x] Update README and relevant documentation
